### PR TITLE
feature/allow custom error handler for iOS

### DIFF
--- a/squidb-android/src/com/yahoo/squidb/android/AndroidOpenHelper.java
+++ b/squidb-android/src/com/yahoo/squidb/android/AndroidOpenHelper.java
@@ -6,6 +6,7 @@
 package com.yahoo.squidb.android;
 
 import android.content.Context;
+import android.database.DatabaseErrorHandler;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.os.Build;
@@ -25,8 +26,8 @@ public class AndroidOpenHelper extends SQLiteOpenHelper implements ISQLiteOpenHe
     private final SquidDatabase.OpenHelperDelegate delegate;
 
     public AndroidOpenHelper(Context context, String name, SquidDatabase.OpenHelperDelegate delegate,
-            int version) {
-        super(context.getApplicationContext(), name, null, version);
+            int version, DatabaseErrorHandler errorHandler) {
+        super(context.getApplicationContext(), name, null, version, errorHandler);
         this.context = context.getApplicationContext();
         this.delegate = delegate;
     }

--- a/squidb-ios/src/com/yahoo/squidb/ios/IOSOpenHelper.java
+++ b/squidb-ios/src/com/yahoo/squidb/ios/IOSOpenHelper.java
@@ -6,6 +6,7 @@
 package com.yahoo.squidb.ios;
 
 import com.google.j2objc.annotations.Weak;
+import com.yahoo.android.sqlite.DatabaseErrorHandler;
 import com.yahoo.android.sqlite.SQLiteDatabase;
 import com.yahoo.android.sqlite.SQLiteOpenHelper;
 import com.yahoo.squidb.data.ISQLiteDatabase;
@@ -24,8 +25,8 @@ public class IOSOpenHelper extends SQLiteOpenHelper implements ISQLiteOpenHelper
     @Weak private final SquidDatabase.OpenHelperDelegate delegate;
 
     public IOSOpenHelper(String path, String name, SquidDatabase.OpenHelperDelegate delegate,
-            int version) {
-        super(path, name, null, version);
+                         int version, DatabaseErrorHandler errorHandler) {
+        super(path, name, null, version, errorHandler);
         this.delegate = delegate;
     }
 


### PR DESCRIPTION
ℹ️  **Disclaimer**: this pull reuqest was started by awesome work of @tomekfab and then finalised by @azubala 

### Context 

We have identified a sporadic issue after performing backup restore (which we call "white screen of death") where after restore is reported to be completed app starts to behave oddly and with few taps user ends up in white screen and nothing can be done. Restarting app leads to clean state of the app and onboarding being presented.

From logs perspective we just see the following log:

```
[ERROR] : DefaultDatabaseErrorHandler - Corruption reported by sqlite on database: /Users/aleksanderzubala/Library/Developer/CoreSimulator/Devices/5AD4C6F2-4E37-4EDB-AEB5-7C9E6A19A624/data/Containers/Data/Application/C31A8D1C-D031-490B-AB8B-DEC22210860E/Documents/Databases/thefabulous.db
[ERROR] : DefaultDatabaseErrorHandler - deleting the database file: /Users/aleksanderzubala/Library/Developer/CoreSimulator/Devices/5AD4C6F2-4E37-4EDB-AEB5-7C9E6A19A624/data/Containers/Data/Application/C31A8D1C-D031-490B-AB8B-DEC22210860E/Documents/Databases/thefabulous.db
[DEBUG] : Database - Database created
```

We have invested a lot of time in the bug investigation (full story in comments in the corresponding story: https://trello.com/c/lfViyH2A) but it turns out that the bug can be reproduced at best 1-2 times out of 10 tries.

Steps to reproduce bug recorded [here](https://drive.google.com/file/d/1ptRLIAfiml2Kii6Cvfh3EXp-F-RqY_9P/view?usp=sharing).

### Details

In order to be able to be able to react on the corruption db event we need to provide custom error handler when creating database. This pull reuqest extends constructor of `IOSOpenHelper` to pass `DatabaseErrorHandler` implementation when creating new DB.